### PR TITLE
Use timeout for urllib.request.urlopen

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def get_download_url() -> Tuple[str, str]:
 
 
 def download(url: str, sha256: str) -> bytes:
-    with urllib.request.urlopen(url) as resp:
+    with urllib.request.urlopen(url, timeout=10.0) as resp:
         code = resp.getcode()
         if code != http.HTTPStatus.OK:
             raise ValueError(f'HTTP failure. Code: {code}')


### PR DESCRIPTION
This attempts to mitigate extremely unusual issue encountered by me in one of my clients environment.

Observations are as following:
- downloading shellcheck binary via curl succeeds
- downloading shellcheck binary using requests/urllib:
  - succeeds when timeout value is provided
  - hangs when timeout value is not provided (eventually request ends up with status 403 forbidden and information in body that it timed out due to 5 minutes timeout)
- downloading other files are not affected, succeeds both using curl and from python code, regardless of timeout value

I am honestly baffled about what exactly happens there. Seems like super weird interference between AWS, Fastly and my environment.

@asottile I'd understand if you will be skeptical to having it merged as it it. Nevertheless, I'd like to trigger a discussion on what we could agree upon to be merged into upstream.