### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v2.6.0
     hooks:
       - id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus]
   - repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -21,4 +20,4 @@ classifiers =
     Programming Language :: Python :: Implementation :: PyPy
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos