### PR TITLE
Fix setuptools deprecation warning about `license_file`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ url = https://github.com/ryanrhee/shellcheck-py
 author = Ryan Rhee
 author_email = pypi@rhee.io
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3


### PR DESCRIPTION
Setuptools spews out this warning when installing the package:

> The license_file parameter is deprecated, use license_files instead.
>
> By 2023-Oct-30, you need to update your project and remove deprecated calls or your builds will no longer be supported.
>
> See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.

This fixes that by switching away from the deprecated `license_file` setting to instead set `licence_files`.

`license_files` has been available since setuptools 42.0.0 released on 23 Nov 2019. `license_file` has been marked as deprecated since setuptools 56.0.0 released on 8 Apr 2021.