### PR TITLE
Edit `README.md` titles utilizing capitalized words

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ A python wrapper to provide a pip-installable [shellcheck] binary.
 Internally this package provides a convenient way to download the pre-built
 shellcheck binary for your particular platform.
 
-### installation
+### Installation
 
 ```bash
 pip install shellcheck-py
 ```
 
-### usage
+### Usage
 
 After installation, the `shellcheck` binary should be available in your
 environment (or `shellcheck.exe` on windows).


### PR DESCRIPTION
After observing the `README.md` seems odd to me that some of the current titles begins with lowercase letters instead of uppercase letters.

This time my contribution is pretty simple, apply a reword around the titles.

## Info
 - This PR doesn't contains unit or integration testing;
 - This PR doesn't introduce changes along the code base;
 - Feel free to review it.
 