### PR TITLE
Remove a non-useful f-string at the `get_download_url()` function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ PY_VERSION = '5'
 def get_download_url() -> tuple[str, str]:
     postfix, sha256 = POSTFIX_SHA256[(sys.platform, platform.machine())]
     url = (
-        f'https://github.com/koalaman/shellcheck/releases/download/'
+        'https://github.com/koalaman/shellcheck/releases/download/'
         f'v{SHELLCHECK_VERSION}/shellcheck-v{SHELLCHECK_VERSION}.{postfix}'
     )
     return url, sha256


### PR DESCRIPTION
While observing the `setup.py` file and function `get_download_url()` I observe 
that there is a non-useful f-string that is trying to help during the `url` definition.

My contribution introduce a removal to the f-string.

## Info

- This PR doesn't contains unit or integration testing;
- This PR doesn't introduce changes along the code base;
- The contribution that I introduce has a small test (at the comments) that compares the output for the current codebase and my contribution;
- Feel free to review it.
