### PR TITLE
fix: spoof UA header for Github Releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ def get_download_url() -> tuple[str, str]:
 
 
 def download(url: str, sha256: str) -> bytes:
-    with urllib.request.urlopen(url) as resp:
+    req = urllib.request.Request(url, headers={'User-Agent': 'curl/8.0.0'})
+    with urllib.request.urlopen(req) as resp:
         code = resp.getcode()
         if code != http.HTTPStatus.OK:
             raise ValueError(f'HTTP failure. Code: {code}')


### PR DESCRIPTION
(I realize this is an absurd thing to have to do)

It seems as though GIthub Releases is blocking at least some portion of urllib request User Agents. We're noticing this with python3.11 exclusively. We've seen the failures on 3.11.1-3.11.4, running on the latest and the previous OSX version on both Apple Silicon and Intel machines as well as running on Debian instances in CircleCI. I've not yet found any official announcement from Github of them trying to do this on purpose.

I also noticed that once I spoofed the UA from my machine, Github _starting allowing non-spoofed requests to work as well_, which makes this even more absurd. Using a non-default header *always* makes it succeed, using the default header only succeeds if you've already gotten a successful response from Github Releases for that object (I'm guessing the User-Agent check is avoided if the object is cached?).

Trying to install from the latest `main`:
```
$ python3.11 -m pip install .
Processing /private/var/folders/7h/c97966217hx9pp1hsgd_0v200000gq/T/tmpenv.6uosr92z/shellcheck-py                                                                                                                                                            
  Installing build dependencies ... done        
  Getting requirements to build wheel ... done                                                                                                                                                                                                               
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: shellcheck-py                                                                                                                                                                                                        
  Building wheel for shellcheck-py (pyproject.toml) ... error  
  error: subprocess-exited-with-error                                                                                                                                                                                                                        
                                                               
  × Building wheel for shellcheck-py (pyproject.toml) did not run successfully.                                                                                                                                                                              
  │ exit code: 1                                               
  ╰─> [4 lines of output]                                                                                                                                                                                                                                    
      running bdist_wheel                                      
      running build                                                                                                                                                                                                                                          
      running fetch_binaries                                   
      error: HTTP Error 503: Backend unavailable, connection timeout
      [end of output]                                          
                                                                                                                              
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for shellcheck-py               
Failed to build shellcheck-py                                                                                                 
ERROR: Could not build wheels for shellcheck-py, which is required to install pyproject.toml-based projects
```

Spoofing the UA header to basically anything else makes it all work.
```
$ python3.11 -m pip install .
Processing /private/var/folders/7h/c97966217hx9pp1hsgd_0v200000gq/T/tmpenv.6uosr92z/shellcheck-py
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: shellcheck-py
  Building wheel for shellcheck-py (pyproject.toml) ... done
  Created wheel for shellcheck-py: filename=shellcheck_py-0.9.0.5-py2.py3-none-macosx_13_0_arm64.whl size=6502105 sha256=4b129d267217c2230a21c17f2006bf12f7e2aa02ae4ddb715044da36db8d6a49
  Stored in directory: /Users/kevin/Library/Caches/pip/wheels/0a/d1/86/e85b5c337e3c6916aff444b1425b27cb53362b62e47f45ec78
Successfully built shellcheck-py
Installing collected packages: shellcheck-py
Successfully installed shellcheck-py-0.9.0.5
```