### PR TITLE
Support Windows on ARM64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ POSTFIX_SHA256 = {
     ),
 }
 POSTFIX_SHA256[('cygwin', 'x86_64')] = POSTFIX_SHA256[('win32', 'AMD64')]
+POSTFIX_SHA256[('win32', 'ARM64')] = POSTFIX_SHA256[('win32', 'AMD64')]
 POSTFIX_SHA256[('darwin', 'arm64')] = POSTFIX_SHA256[('darwin', 'x86_64')]
 POSTFIX_SHA256[('linux', 'armv7l')] = POSTFIX_SHA256[('linux', 'armv6hf')]
 PY_VERSION = '5'


### PR DESCRIPTION
Reuse AMD64 binary on ARM64. This relies on Windows 11 x64 emulation on ARM64, but still better than not being able to install the package at all.

Cheers,
Jiri

![PTC logo email](https://user-images.githubusercontent.com/44769714/83034194-45548080-a038-11ea-9960-de502a30d89d.png)

**Jiri Hörner**
Senior Software Development Engineer

[jhoerner@ptc.com](mailto:jhoerner@ptc.com)
[ptc.com](http://www.ptc.com/)