### PR TITLE
add support for RISC-V architecture under Linux

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,13 @@ download_scripts =
     extract_path = shellcheck-v0.10.0/shellcheck
     [shellcheck]
     group = shellcheck-binary
+    marker = sys_platform == "linux" and platform_machine == "riscv64"
+    url = https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.riscv64.tar.xz
+    sha256 = be1f2028951783424c7a5dc744ac0bab8d5b181189e80f640cc56f481f1e371e
+    extract = tar
+    extract_path = linux.riscv64/shellcheck
+    [shellcheck]
+    group = shellcheck-binary
     marker = sys_platform == "linux" and platform_machine == "x86_64"
     url = https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz
     sha256 = 6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87


### PR DESCRIPTION
Note the different archive content in the RISC-V archive.

Fixes: #129 