### PR TITLE
Replace wheel's bdist_wheel with setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from setuptools import setup
 
 try:
-    from wheel.bdist_wheel import bdist_wheel as orig_bdist_wheel
+    from setuptools.command.bdist_wheel import bdist_wheel as orig_bdist_wheel
 except ImportError:
     cmdclass = {}
 else:


### PR DESCRIPTION
This fixes a warning of a removal in October 2025.

Fixes #140

_(This was done in GitHub's editor, relying on CI tests to catch if it's right.)_